### PR TITLE
execinquery(bug): fix cmd extraction logic

### DIFF
--- a/passes/execinquery/execinquery.go
+++ b/passes/execinquery/execinquery.go
@@ -155,12 +155,8 @@ func inspectCallExpr(pass *analysis.Pass, callExpr *ast.CallExpr, vars map[strin
 	}
 
 	query = strings.TrimSpace(cleanValue(query))
-	delim := strings.IndexByte(query, ' ')
-	if delim == -1 {
-		return
-	}
 
-	cmd := query[:delim]
+	cmd := extractCmd(query)
 	if strings.EqualFold(cmd, "SELECT") || strings.EqualFold(cmd, "SHOW") {
 		return
 	}
@@ -210,6 +206,24 @@ func getQueryString(exp any, vars map[string]ast.Expr) string {
 	}
 
 	return ""
+}
+
+func extractCmd(query string) string {
+	start, end := -1, len(query)
+	for i, r := range query {
+		if start == -1 && (r > ' ' && r < '~') {
+			start = i
+			continue
+		}
+		if start != -1 && (r <= ' ' || r >= '~') {
+			end = i
+			break
+		}
+	}
+	if start == -1 {
+		return ""
+	}
+	return query[start:end]
 }
 
 func cleanValue(s string) string {

--- a/passes/execinquery/testdata/src/a/a.go
+++ b/passes/execinquery/testdata/src/a/a.go
@@ -151,6 +151,16 @@ UPDATE * ` + `FROM test` + ` WHERE test=?`
 		builder += ` AND test2=?`
 	}
 	_ = db.QueryRow(builder, s)
+
+	contextID := "199999123512514"
+	f9 := `
+		SELECT
+			id, context_id
+		FROM messages
+		WHERE context_id = $1
+		ORDER BY created_at ASC
+	`
+	_, _ = db.Query(f9, contextID)
 }
 
 func queryFunc() string {


### PR DESCRIPTION
Fix case where properly formatted query string could be reported.

Example:

```go
query := `
    SELECT
        user
    FROM accounts
    WHERE
        id = $1
    ;
`
```